### PR TITLE
net.urllib: avoid double free in set_path()

### DIFF
--- a/vlib/net/urllib/urllib.v
+++ b/vlib/net/urllib/urllib.v
@@ -622,15 +622,8 @@ fn parse_host(host string) ?string {
 // set_path will return an error only if the provided path contains an invalid
 // escaping.
 pub fn (mut u URL) set_path(p string) ?bool {
-	path := unescape(p, .encode_path) ?
-	u.path = path
-	escp := escape(path, .encode_path)
-	if p == escp {
-		// Default encoding is fine.
-		u.raw_path = ''
-	} else {
-		u.raw_path = p
-	}
+	u.path = unescape(p, .encode_path) ?
+	u.raw_path = if p == escape(u.path, .encode_path) { '' } else { p }
 	return true
 }
 


### PR DESCRIPTION
Fix set_path() in net.urllib to avoid double free.
`v -autofree run examples/vweb/` should run now.
Fix #7797.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
