### PR TITLE
v.builder: fix cross compiling to windows directory with spaces

### DIFF
--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -770,9 +770,10 @@ fn (mut c Builder) cc_windows_cross() {
 	c.setup_ccompiler_options(c.pref.ccompiler)
 	c.build_thirdparty_obj_files()
 	c.setup_output_name()
-	if !c.pref.out_name.ends_with('.exe') {
+	if !c.pref.out_name.to_lower().ends_with('.exe') {
 		c.pref.out_name += '.exe'
 	}
+	c.pref.out_name = os.quoted_path(c.pref.out_name)
 	mut args := []string{}
 	args << '$c.pref.cflags'
 	args << '-o $c.pref.out_name'
@@ -810,7 +811,7 @@ fn (mut c Builder) cc_windows_cross() {
 	}
 	// add the thirdparty .o files, produced by all the #flag directives:
 	args << cflags.c_options_only_object_files()
-	args << c.out_name_c
+	args << os.quoted_path(c.out_name_c)
 	if c.pref.ccompiler == 'msvc' {
 		args << cflags.c_options_after_target_msvc()
 	} else {


### PR DESCRIPTION

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
